### PR TITLE
Revert "Bump sollie/docker-upx from v4.2.4 to v5.0.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk --no-cache add ca-certificates tzdata
 ADD source /builder
 RUN CGO_ENABLED=0 go build -o cloudflare-dyndns
 
-FROM ghcr.io/sollie/docker-upx:v5.0.0 AS upx
+FROM ghcr.io/sollie/docker-upx:v4.2.4 AS upx
 WORKDIR /upx
 COPY --from=builder /builder/cloudflare-dyndns /upx/cloudflare-dyndns
 RUN upx --best cloudflare-dyndns


### PR DESCRIPTION
This reverts commit 0e1acf68d93c361b8461487c477846f8aa996c8a.